### PR TITLE
Scroll en weather page

### DIFF
--- a/lib/presentation/pages/weather_page.dart
+++ b/lib/presentation/pages/weather_page.dart
@@ -105,7 +105,6 @@ class WeatherPage extends StatelessWidget {
               mainAxisSpacing: 10,
               childAspectRatio: 1 / .5,
               shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
               children: [
                 WeatherDetailCard(
                   label: "Humedad",


### PR DESCRIPTION
Elimina la propiedad NeverScrollableScrollPhysics del widget GridView en WeatherPage para permitir el desplazamiento.